### PR TITLE
Fix word translation

### DIFF
--- a/files/pt-br/web/javascript/guide/loops_and_iteration/index.html
+++ b/files/pt-br/web/javascript/guide/loops_and_iteration/index.html
@@ -162,11 +162,11 @@ while (n &lt; 3) {
 <pre class="syntaxbox">label : declaracao
 </pre>
 
-<p>Um label pode usar qualquer idenficador que não seja uma palavra reservada do JavaScript. Você pode identificar qualquer instrução com um label.</p>
+<p>Um label pode usar qualquer identificador que não seja uma palavra reservada do JavaScript. Você pode identificar qualquer instrução com um label.</p>
 
 <h3 id="Exemplo_3"><strong>Exemplo</strong></h3>
 
-<p>Neste exemplo, o label <code>markLoop</code> idenfica um laço <code>while</code>.</p>
+<p>Neste exemplo, o label <code>markLoop</code> identifica um laço <code>while</code>.</p>
 
 <pre class="brush: js">markLoop:
 while (theMark == true) {


### PR DESCRIPTION
Fix error on word "idenfica". The correct word should be "identifica", as it is in Portuguese.